### PR TITLE
Can't delete user from admin panel.

### DIFF
--- a/root/settings.py
+++ b/root/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     # 3rd-party apps
     'allauth',
     'allauth.account',
+    'allauth.socialaccount',
     'rest_framework',
     'rest_framework.authtoken',
     'rest_framework_simplejwt.token_blacklist',


### PR DESCRIPTION
Fixes #4

The errors had been showing because of the `allauth` package. It needs a dependency `allauth.socialaccount` in the `INSTALLED_APP` dictionary.

Now everything is working well 🎉

![image](https://user-images.githubusercontent.com/48384104/195002583-885b4bd0-71e1-4b6b-a157-74623d85380f.png)
