### PR TITLE
Registration no include auth cookies.

### DIFF
--- a/credentials/api/urls.py
+++ b/credentials/api/urls.py
@@ -1,9 +1,39 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
 from credentials.api.views import get_tokens_for_user
+from dj_rest_auth.registration.views import VerifyEmailView, ResendEmailVerificationView
+from credentials.api.views import RegisterViewWithSetCookies
+from django.views.generic import TemplateView
+
+
+registration_urls = [
+    path('', RegisterViewWithSetCookies.as_view()),
+    path('verify-email/', VerifyEmailView.as_view(), name='rest_verify_email'),
+    path('resend-email/', ResendEmailVerificationView.as_view(), name="rest_resend_email"),
+
+    # This url is used by django-allauth and empty TemplateView is
+    # defined just to allow reverse() call inside app, for example when email
+    # with verification link is being sent, then it's required to render email
+    # content.
+
+    # account_confirm_email - You should override this view to handle it in
+    # your API client somehow and then, send post to /verify-email/ endpoint
+    # with proper key.
+    # If you don't want to use API on that step, then just use ConfirmEmailView
+    # view from:
+    # django-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
+    re_path(
+        r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
+        name='account_confirm_email',
+    ),
+    path(
+        'account-email-verification-sent/', TemplateView.as_view(),
+        name='account_email_verification_sent',
+    ),
+]
 
 
 urlpatterns = [
     path('', include('dj_rest_auth.urls')),
-    path('registration/', include('dj_rest_auth.registration.urls')),
+    path('registration/', include(registration_urls)),
     path('get/refresh/', get_tokens_for_user),
 ]

--- a/credentials/api/views.py
+++ b/credentials/api/views.py
@@ -3,6 +3,8 @@ from django.http import JsonResponse
 from credentials.api.serializers import CustomUserDetailSerializer
 from django.contrib.auth import get_user_model
 from dj_rest_auth.jwt_auth import set_jwt_cookies
+from dj_rest_auth.registration.views import RegisterView
+from django.conf import settings
 
 
 def get_tokens_for_user(request):
@@ -27,3 +29,14 @@ def get_tokens_for_user(request):
             'status': 404,
             'message': str(e)
         })
+
+
+class RegisterViewWithSetCookies(RegisterView):
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
+        set_jwt_cookies(
+            response=response,
+            access_token=response.data[getattr(settings, 'JWT_AUTH_COOKIE', 'access_token')],
+            refresh_token=response.data[getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', 'refresh_token')]
+        )
+        return response

--- a/root/settings.py
+++ b/root/settings.py
@@ -198,7 +198,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Simple-JWT
 REST_USE_JWT = True
-# JWT_AUTH_COOKIE = 'access_token'
+JWT_AUTH_COOKIE = 'access_token'
 JWT_AUTH_REFRESH_COOKIE = 'refresh_token'
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),


### PR DESCRIPTION
Fixes #8

Now, the registration endpoint will also set the auth cookies with the response object.
![image](https://user-images.githubusercontent.com/48384104/196452844-f4144fb0-68ff-49e3-a963-541b554bd3cb.png)
